### PR TITLE
Fix fullscreen intro animation

### DIFF
--- a/css/header.scss
+++ b/css/header.scss
@@ -94,6 +94,7 @@ header {
   &[data-fullscreen="true"] {
     justify-content: center;
     min-height: 100vh;
+    animation: greyscale 1s ease-in;
 
     .logo > * {
       height: 200px;
@@ -101,14 +102,20 @@ header {
 
       @keyframes logo_zoom {
         0% {
-          transform: scale(2) translateX(14.666%);
-        }
-        50% {
-          transform: scale(1) translateX(14.666%);
+          transform: scale(2);
         }
         100% {
-          transform: scale(1) translateX(0);
+          transform: scale(1);
         }
+      }
+    }
+
+    @keyframes greyscale {
+      0% {
+        filter: grayscale(100%);
+      }
+      100% {
+        filter: grayscale(0%);
       }
     }
 


### PR DESCRIPTION
Removes logo shift and adds greyscale image fade.

Closes #16 

More info at https://github.com/Mangul-Lab-USC/Mangul-Lab-USC.github.io/issues/16#issuecomment-851058672