### PR TITLE
Remove research duplicates and update article images

### DIFF
--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -48,6 +48,10 @@
 # Url to link to. If not specified, defaults to the url that Manubot returns for
 # the citation.
 
+# Note: Go to the doi link where the paper is published
+# and retrieve a direct link to a figure from the paper before adding an article...
+# Do not use the same image for multiple articles... - Jaden :)
+
 - id: doi:10.1186/s13059-018-1403-7
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
@@ -56,17 +60,17 @@
     - ovarian cancer
 
 - id: doi:10.1038/s41467-020-16857-7
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-020-16857-7/MediaObjects/41467_2020_16857_Fig1_HTML.png
   tags:
     - cancer
     - machine learning
 
 - id: doi:10.1093/bioinformatics/btu295
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/bioinformatics/30/12/10.1093/bioinformatics/btu295/2/m_btu295f1.png?Expires=1626245276&Signature=tikBJOeTlbSqeLtgXLnZXqoXJ7aJxeYPL0WQUoA9Ai7~pkzaXJmrc0wv0lLJwukQgqpGjXAjDw2yJ4v1W9PpedVkbH9V9Ru5HFtBaLvuW~0U0C3Ws5V6IYApLF79PfThrTyqlw3bPXcgVhXnidKKdEhByoTeSlCSF6MG-M8cJM~smgeNiJtBkfmA7knaEYK8Ckq9~Wp13hmj-bDoMCjNnmh~jtj4Y3kzSuLls0OdWMZ0fNY9U8tKmLwHbAR4AH5sD6d4Dq-65SzZ30QjwZkJQ-q2TMK2PFw59O5srsDokkwGh6WSefowfnw17NZIcPkFyZbp-yR6g8X4S5H1fo7U3w__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA
 
 
 - id: doi:10.1186/s13059-020-01988-3
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-01988-3/MediaObjects/13059_2020_1988_Fig1_HTML.png
   tags:
     - cancer
     - single cell
@@ -102,41 +106,41 @@
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1016/j.tibtech.2017.06.007
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: ''
 
 - id: doi:10.1186/s13059-020-02159-0
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02159-0/MediaObjects/13059_2020_2159_Fig1_HTML.png
 
 - id: doi:10.1186/s13059-020-02252-4
-  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png?as=webp
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02026-y
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02026-y/MediaObjects/13059_2020_2026_Fig6_HTML.png
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02129-6
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02129-6/MediaObjects/13059_2020_2129_Fig4_HTML.png
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02113-0
-  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png?as=webp
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02122-z
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02122-z/MediaObjects/13059_2020_2122_Fig2_HTML.png
   tags:
     - cancer
     - single cell
@@ -150,28 +154,28 @@
     - ovarian cancer
 
 - id: doi:10.1126/science.aba3066
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaba3066/F1.large.jpg?width=800&height=600
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1126/science.aaz1776
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/1318/F2.large.jpg?width=800&height=600
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1126/science.aaz8528
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz8528/F3.large.jpg?width=800&height=600
   tags:
     - cancer
     - single cell
     - ovarian cancer
 
 - id: doi:10.1126/science.aaz6876
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz6876/F1.large.jpg?width=800&height=600
   tags:
     - cancer
     - single cell
@@ -185,11 +189,7 @@
     - ovarian cancer
 
 - id: doi:10.31219/osf.io/3gdy4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-    - cancer
-    - single cell
-    - ovarian cancer
+  image: ''
 
 - id: doi:10.1186/s13059-019-1649-8
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
@@ -198,7 +198,7 @@
     - machine learning
 
 - id: doi:10.1186/s12915-020-0756-z
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs12915-020-0756-z/MediaObjects/12915_2020_756_Fig1_HTML.png
   tags:
     - cancer
     - machine learning
@@ -222,13 +222,13 @@
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
 - id: doi:10.1038/nature24277
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fnature24277/MediaObjects/41586_2017_Article_BFnature24277_Fig1_HTML.jpg
 
 - id: doi:10.1038/nature24041
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fnature24041/MediaObjects/41586_2017_Article_BFnature24041_Fig1_HTML.jpg
 
 - id: doi:10.1101/gr.216721.116
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
 
 - id: doi:10.1101/2020.04.16.045120
   image: https://www.biorxiv.org/content/biorxiv/early/2020/09/17/2020.04.16.045120/F2.large.jpg?width=800&height=600
@@ -238,7 +238,7 @@
       link: https://www.biorxiv.org/content/10.1101/2020.04.16.045120v1
 
 - id: doi:2003.00110
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
     - type: preprint
     - type: manubot
@@ -272,7 +272,7 @@
     - machine learning
 
 - id: doi:1911.11304
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
     - type: preprint
     - type: manubot
@@ -282,7 +282,7 @@
     - machine learning
 
 - id: doi:10.1101/833210
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/03/13/833210/F1.large.jpg?width=800&height=600
   extra-links:
     - type: preprint
     - type: manubot
@@ -292,7 +292,7 @@
     - machine learning
 
 - id: doi:10.1101/808295
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2019/10/17/808295/F2.large.jpg?width=800&height=600
   extra-links:
     - type: preprint
     - type: manubot
@@ -302,7 +302,7 @@
     - machine learning
 
 - id: doi:10.1101/806117
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2019/10/17/806117/F3.large.jpg?width=800&height=600
   extra-links:
     - type: preprint
     - type: manubot

--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -101,19 +101,7 @@
     - single cell
     - ovarian cancer
 
-- id: doi:10.1186/s13059-019-1649-8
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
-- id: doi:10.1186/s12915-020-0756-z
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
-- id: doi:10.1042/ETLS20180175
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
 - id: doi:10.1038/nbt.4113
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
-- id: doi:10.1074/jbc.RA119.008853
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1074/jbc.RA119.008853
@@ -122,16 +110,10 @@
 - id: doi:10.1093/nar/gkz822
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
-- id: doi:10.1074/jbc.RA119.008853
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
 - id: doi:10.1007/978-3-030-13973-5_1
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1016/j.isci.2018.11.024
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
-- id: doi:10.1038/nbt.4113
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1016/j.tibtech.2017.06.007
@@ -169,20 +151,6 @@
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02122-z
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-    - cancer
-    - single cell
-    - ovarian cancer
-
-- id: doi:10.1186/s12915-020-0756-z
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-    - cancer
-    - single cell
-    - ovarian cancer
-
-- id: doi:10.1186/s13059-020-01988-3
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
     - cancer
@@ -245,19 +213,7 @@
     - single cell
     - ovarian cancer
 
-- id: doi:10.1186/s13059-020-01988-3
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-    - cancer
-    - machine learning
-
 - id: doi:10.1038/s41467-019-09406-4
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-    - cancer
-    - machine learning
-
-- id: doi:10.1371/journal.pbio.3000333
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
   tags:
     - cancer
@@ -284,9 +240,6 @@
 - id: doi:10.1038/s41587-019-0053-y
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
-- id: doi:10.1038/nbt.4113
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-
 - id: doi:10.3389/fimmu.2018.02206
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
@@ -300,9 +253,6 @@
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
 - id: doi:10.1038/nature24041
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-
-- id: doi:10.1038/s41398-018-0107-9
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
 - id: doi:10.1101/gr.216721.116
@@ -333,7 +283,7 @@
       link: https://doi.org/10.1101/785584
 
 - id: url:https://arxiv.org/abs/2002.12268
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
     - type: preprint
     - type: manubot
@@ -341,20 +291,6 @@
   tags:
     - cancer
     - machine learning
-
-- id: url:https://arxiv.org/abs/2002.12268
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-    - type: preprint
-    - type: manubot
-      link: https://arxiv.org/abs/2002.12268
-
-- id: url:https://arxiv.org/abs/2002.12268
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-    - type: preprint
-    - type: manubot
-      link: https://arxiv.org/abs/2002.12268
 
 - id: doi:10.1101/2020.01.17.910521
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png

--- a/_data/research-input.yml
+++ b/_data/research-input.yml
@@ -55,26 +55,11 @@
     - single cell
     - ovarian cancer
 
-- id: doi:10.1186/s13059-018-1403-7
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-    - cancer
-    - single cell
-    - ovarian cancer
-
 - id: doi:10.1038/s41467-020-16857-7
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
   tags:
     - cancer
     - machine learning
-
-- id: doi:doi:10.1186/s13059-018-1403-7
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
-
-- id: doi:10.1038/s41467-020-16857-7
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-
 
 - id: doi:10.1093/bioinformatics/btu295
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
@@ -108,7 +93,7 @@
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1093/nar/gkz822
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/nar/48/D1/10.1093_nar_gkz822/1/gkz822fig2.jpeg?Expires=1627396020&Signature=0zOulYw0i2LLSmY8mQHgoCJAay~ccQuLxUhZqvcjEqog10p2dGj05uxonDH66c7~69KmN0joOPaAfVRMjfUfwV72I5rPB8ctOesZVAIQacRPyjgUBHFjEr~y~nFEOkKqTA1CqETli5qqN-cdTgNCu64pyllxjrbITWheWZ5hRJ88KQIuZMlq7MxrVkgnOL-UZ0ipxseAccWLAMWJPFzAsgrjIa~vWuR42oiA3Dl7jjJ1Oz1UzlJn~6aLEzfBC1OmPduICHxa~7~l2eVCU13D8lfqYIJJVuEIPysIBQ0TLVRM0F9NH7a7qHFJN27a7Jwuv7Nta6bd3IK1KB80~XjjZg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA
 
 - id: doi:10.1007/978-3-030-13973-5_1
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
@@ -123,7 +108,7 @@
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 
 - id: doi:10.1186/s13059-020-02252-4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png?as=webp
   tags:
     - cancer
     - single cell
@@ -144,7 +129,7 @@
     - ovarian cancer
 
 - id: doi:10.1186/s13059-020-02113-0
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png?as=webp
   tags:
     - cancer
     - single cell
@@ -158,7 +143,7 @@
     - ovarian cancer
 
 - id: doi:10.31219/osf.io/v5kr4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: ''
   tags:
     - cancer
     - single cell
@@ -193,7 +178,7 @@
     - ovarian cancer
 
 - id: doi:10.1126/science.aaz5900
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz5900/F1.large.jpg?width=800&height=600
   tags:
     - cancer
     - single cell
@@ -205,19 +190,6 @@
     - cancer
     - single cell
     - ovarian cancer
-
-- id: doi:10.31219/osf.io/3gdy4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-    - cancer
-    - single cell
-    - ovarian cancer
-
-- id: doi:10.1038/s41467-019-09406-4
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-    - cancer
-    - machine learning
 
 - id: doi:10.1186/s13059-019-1649-8
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
@@ -258,11 +230,8 @@
 - id: doi:10.1101/gr.216721.116
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
 
-- id: doi:10.1101/gr.216721.116
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-
 - id: doi:10.1101/2020.04.16.045120
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/09/17/2020.04.16.045120/F2.large.jpg?width=800&height=600
   extra-links:
     - type: preprint
     - type: manubot
@@ -293,7 +262,7 @@
     - machine learning
 
 - id: doi:10.1101/2020.01.17.910521
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/01/18/2020.01.17.910521/F1.large.jpg?width=800&height=600
   extra-links:
     - type: preprint
     - type: manubot
@@ -322,16 +291,6 @@
     - cancer
     - machine learning
 
-- id: doi:10.1101/814350
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-    - type: preprint
-    - type: manubot
-      link: https://doi.org/10.1101/814350
-  tags:
-    - cancer
-    - machine learning
-
 - id: doi:10.1101/808295
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
   extra-links:
@@ -351,20 +310,6 @@
   tags:
     - cancer
     - machine learning
-
-- id: doi:10.1101/785584
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-    - type: preprint
-    - type: manubot
-      link: https://doi.org/10.1101/785584
-
-- id: doi:10.1101/785584
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-    - type: preprint
-    - type: manubot
-      link: https://doi.org/10.1101/785584
 
 - id: doi:10.1101/793091
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -59,7 +59,7 @@
   date: '2020-06-19'
   link: https://doi.org/ghqfdr
   id: doi:10.1038/s41467-020-16857-7
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-020-16857-7/MediaObjects/41467_2020_16857_Fig1_HTML.png
   tags:
   - cancer
   - machine learning
@@ -75,7 +75,7 @@
   date: '2014-06-15'
   link: https://doi.org/f58h9q
   id: doi:10.1093/bioinformatics/btu295
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/bioinformatics/30/12/10.1093/bioinformatics/btu295/2/m_btu295f1.png?Expires=1626245276&Signature=tikBJOeTlbSqeLtgXLnZXqoXJ7aJxeYPL0WQUoA9Ai7~pkzaXJmrc0wv0lLJwukQgqpGjXAjDw2yJ4v1W9PpedVkbH9V9Ru5HFtBaLvuW~0U0C3Ws5V6IYApLF79PfThrTyqlw3bPXcgVhXnidKKdEhByoTeSlCSF6MG-M8cJM~smgeNiJtBkfmA7knaEYK8Ckq9~Wp13hmj-bDoMCjNnmh~jtj4Y3kzSuLls0OdWMZ0fNY9U8tKmLwHbAR4AH5sD6d4Dq-65SzZ30QjwZkJQ-q2TMK2PFw59O5srsDokkwGh6WSefowfnw17NZIcPkFyZbp-yR6g8X4S5H1fo7U3w__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA
   tags:
   - sequencing
   - viral population assembly
@@ -112,7 +112,7 @@
   date: '2020-03-17'
   link: https://doi.org/ghqfds
   id: doi:10.1186/s13059-020-01988-3
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-01988-3/MediaObjects/13059_2020_1988_Fig1_HTML.png
   tags:
   - cancer
   - single cell
@@ -266,7 +266,7 @@
   date: '2017-10-01'
   link: https://doi.org/ghqfdw
   id: doi:10.1016/j.tibtech.2017.06.007
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: ''
   tags:
   - cancer
   - single cell
@@ -283,7 +283,7 @@
   date: '2020-09-10'
   link: https://doi.org/ghtqrz
   id: doi:10.1186/s13059-020-02159-0
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02159-0/MediaObjects/13059_2020_2159_Fig1_HTML.png
   tags:
   - cancer
   - single cell
@@ -324,7 +324,7 @@
   date: '2021-01-26'
   link: https://doi.org/ghxdc9
   id: doi:10.1186/s13059-020-02252-4
-  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png?as=webp
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png
   tags:
   - cancer
   - single cell
@@ -345,7 +345,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghxddb
   id: doi:10.1186/s13059-020-02026-y
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02026-y/MediaObjects/13059_2020_2026_Fig6_HTML.png
   tags:
   - cancer
   - single cell
@@ -369,7 +369,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghxddc
   id: doi:10.1186/s13059-020-02129-6
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02129-6/MediaObjects/13059_2020_2129_Fig4_HTML.png
   tags:
   - cancer
   - single cell
@@ -401,7 +401,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghxddg
   id: doi:10.1186/s13059-020-02113-0
-  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png?as=webp
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png
   tags:
   - cancer
   - single cell
@@ -418,7 +418,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghxddj
   id: doi:10.1186/s13059-020-02122-z
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs13059-020-02122-z/MediaObjects/13059_2020_2122_Fig2_HTML.png
   tags:
   - cancer
   - single cell
@@ -485,7 +485,7 @@
   date: '2020-09-10'
   link: https://doi.org/ghbnkj
   id: doi:10.1126/science.aba3066
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaba3066/F1.large.jpg?width=800&height=600
   tags:
   - cancer
   - single cell
@@ -497,7 +497,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghbnhr
   id: doi:10.1126/science.aaz1776
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/1318/F2.large.jpg?width=800&height=600
   tags:
   - cancer
   - single cell
@@ -543,7 +543,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghbnkh
   id: doi:10.1126/science.aaz8528
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz8528/F3.large.jpg?width=800&height=600
   tags:
   - cancer
   - single cell
@@ -577,7 +577,7 @@
   date: '2020-09-10'
   link: https://doi.org/ghbsdk
   id: doi:10.1126/science.aaz6876
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz6876/F1.large.jpg?width=800&height=600
   tags:
   - cancer
   - single cell
@@ -644,7 +644,7 @@
   date: '2020-08-26'
   link: https://doi.org/ghxdff
   id: doi:10.31219/osf.io/3gdy4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: ''
   tags:
   - cancer
   - single cell
@@ -675,7 +675,7 @@
   date: '2020-04-07'
   link: https://doi.org/ghqfdt
   id: doi:10.1186/s12915-020-0756-z
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/lw685/springer-static/image/art%3A10.1186%2Fs12915-020-0756-z/MediaObjects/12915_2020_756_Fig1_HTML.png
   tags:
   - cancer
   - machine learning
@@ -782,7 +782,7 @@
   date: '2017-10-12'
   link: https://doi.org/gb2nqv
   id: doi:10.1038/nature24277
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fnature24277/MediaObjects/41586_2017_Article_BFnature24277_Fig1_HTML.jpg
   tags:
   - cancer
   - machine learning
@@ -822,7 +822,7 @@
   date: '2017-10-12'
   link: https://doi.org/gb2qv5
   id: doi:10.1038/nature24041
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fnature24041/MediaObjects/41586_2017_Article_BFnature24041_Fig1_HTML.jpg
   tags:
   - cancer
   - machine learning
@@ -842,7 +842,7 @@
   date: '2017-11-01'
   link: https://doi.org/gb2qx6
   id: doi:10.1101/gr.216721.116
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   tags:
   - cancer
   - machine learning
@@ -899,7 +899,7 @@
   date: '2020-07-09'
   link: https://doi.org/2003.00110
   id: doi:2003.00110
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
   - type: preprint
   - type: manubot
@@ -990,7 +990,7 @@
   date: '2020-08-07'
   link: https://doi.org/1911.11304
   id: doi:1911.11304
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
   - type: preprint
   - type: manubot
@@ -1014,7 +1014,7 @@
   date: '2020-03-13'
   link: https://doi.org/gg334k
   id: doi:10.1101/833210
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/03/13/833210/F1.large.jpg?width=800&height=600
   extra-links:
   - type: preprint
   - type: manubot
@@ -1038,7 +1038,7 @@
   date: '2019-10-17'
   link: https://doi.org/ghqfdz
   id: doi:10.1101/808295
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2019/10/17/808295/F2.large.jpg?width=800&height=600
   extra-links:
   - type: preprint
   - type: manubot
@@ -1086,7 +1086,7 @@
   date: '2019-10-17'
   link: https://doi.org/ggh6r5
   id: doi:10.1101/806117
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2019/10/17/806117/F3.large.jpg?width=800&height=600
   extra-links:
   - type: preprint
   - type: manubot

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -31,8 +31,11 @@
   link: https://doi.org/ggn2dj
   id: doi:10.1186/s13059-018-1403-7
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  tags:
+  - cancer
+  - single cell
+  - ovarian cancer
 - *id001
-
 - &id002
   title: Profiling immunoglobulin repertoires across multiple human tissues using
     RNA sequencing
@@ -61,10 +64,41 @@
   id: doi:10.1038/s41467-020-16857-7
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
-  - immune repertoire
-  - RNA-seq
+  - cancer
+  - machine learning
+- title: 'ROP: dumpster diving in RNA-sequencing to find the source of 1 trillion
+    reads across diverse adult human tissues'
+  authors:
+  - Serghei Mangul
+  - Harry Taegyun Yang
+  - Nicolas Strauli
+  - Franziska Gruhl
+  - Hagit T. Porath
+  - Kevin Hsieh
+  - Linus Chen
+  - Timothy Daley
+  - Stephanie Christenson
+  - Agata Wesolowska-Andersen
+  - Roberto Spreafico
+  - Cydney Rios
+  - Celeste Eng
+  - Andrew D. Smith
+  - Ryan D. Hernandez
+  - Roel A. Ophoff
+  - Jose Rodriguez Santana
+  - Erez Y. Levanon
+  - Prescott G. Woodruff
+  - Esteban Burchard
+  - Max A. Seibold
+  - Sagiv Shifman
+  - Eleazar Eskin
+  - Noah Zaitlen
+  publisher: Genome Biology
+  date: '2018-02-15'
+  link: https://doi.org/ggn2dj
+  id: doi:doi:10.1186/s13059-018-1403-7
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
 - *id002
-
 - title: Accurate viral population assembly from ultra-deep sequencing data
   authors:
   - S. Mangul
@@ -81,9 +115,7 @@
   tags:
   - sequencing
   - viral population assembly
-  
-- &id005
-  title: Benchmarking of computational error-correction methods for next-generation
+- title: Benchmarking of computational error-correction methods for next-generation
     sequencing data
   authors:
   - Keith Mitchell
@@ -116,12 +148,12 @@
   date: '2020-03-17'
   link: https://doi.org/ghqfds
   id: doi:10.1186/s13059-020-01988-3
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
-  - benchmarking
-  - machine learning
- 
-- &id006
+  - cancer
+  - single cell
+  - ovarian cancer
+- &id004
   title: Systematic benchmarking of omics computational tools
   authors:
   - Serghei Mangul
@@ -138,11 +170,9 @@
   id: doi:10.1038/s41467-019-09406-4
   image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
   tags:
-  - benchmarking
+  - cancer
   - machine learning
-  
-- &id007
-  title: Challenges and recommendations to improve the installability and archival
+- title: Challenges and recommendations to improve the installability and archival
     stability of omics computational tools
   authors:
   - Serghei Mangul
@@ -166,61 +196,12 @@
   date: '2019-06-20'
   link: https://doi.org/dm26
   id: doi:10.1371/journal.pbio.3000333
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
-  - installability
-  - archival stability
-  - omics tools
-  
-- &id008
-  title: Improving the usability and archival stability of bioinformatics software
-  authors:
-  - Serghei Mangul
-  - Lana S. Martin
-  - Eleazar Eskin
-  - Ran Blekhman
-  publisher: Genome Biology
-  date: '2019-02-27'
-  link: https://doi.org/ggc6j6
-  id: doi:10.1186/s13059-019-1649-8
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - archival stability
-  - omics software
- 
-- &id004
-  title: Improving the usability and comprehensiveness of microbial databases
-  authors:
-  - Caitlin Loeffler
-  - Aaron Karlsberg
-  - Lana S. Martin
-  - Eleazar Eskin
-  - David Koslicki
-  - Serghei Mangul
-  publisher: BMC Biology
-  date: '2020-04-07'
-  link: https://doi.org/ghqfdt
-  id: doi:10.1186/s12915-020-0756-z
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - microbiome
-  - usability
-  
-- &id009
-  title: Interpreting and integrating big data in the life sciences
-  authors:
-  - Serghei Mangul
-  publisher: Emerging Topics in Life Sciences
-  date: '2019-08-16'
-  link: https://doi.org/d53v
-  id: doi:10.1042/ETLS20180175
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - big data
-  - machine learning
- 
-- &id003
-  title: "Involving undergraduates in genomics research to narrow the education\u2013\
+  - cancer
+  - single cell
+  - ovarian cancer
+- title: "Involving undergraduates in genomics research to narrow the education\u2013\
     research gap"
   authors:
   - Serghei Mangul
@@ -230,29 +211,10 @@
   date: '2018-04-01'
   link: https://doi.org/ghqfdv
   id: doi:10.1038/nbt.4113
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - cancer
-  - machine learning
-- title: Transcriptional profiling of single fiber cells in a transgenic paradigm
-    of an inherited childhood cataract reveals absence of molecular heterogeneity
-  authors:
-  - Suraj P. Bhat
-  - Rajendra K. Gangalum
-  - Dongjae Kim
-  - Serghei Mangul
-  - Raj K. Kashyap
-  - Xinkai Zhou
-  - David Elashoff
-  publisher: Journal of Biological Chemistry
-  date: '2019-09-01'
-  link: https://doi.org/ghp82b
-  id: doi:10.1074/jbc.RA119.008853
   image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
   - cancer
-  - single cell
-  - ovarian cancer
+  - machine learning
 - title: Transcriptional profiling of single fiber cells in a transgenic paradigm
     of an inherited childhood cataract reveals absence of molecular heterogeneity
   authors:
@@ -294,25 +256,6 @@
   - cancer
   - single cell
   - ovarian cancer
-- title: Transcriptional profiling of single fiber cells in a transgenic paradigm
-    of an inherited childhood cataract reveals absence of molecular heterogeneity
-  authors:
-  - Suraj P. Bhat
-  - Rajendra K. Gangalum
-  - Dongjae Kim
-  - Serghei Mangul
-  - Raj K. Kashyap
-  - Xinkai Zhou
-  - David Elashoff
-  publisher: Journal of Biological Chemistry
-  date: '2019-09-01'
-  link: https://doi.org/ghp82b
-  id: doi:10.1074/jbc.RA119.008853
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-  tags:
-  - cancer
-  - single cell
-  - ovarian cancer
 - title: Hidden Treasures in Contemporary RNA Sequencing
   authors:
   - Serghei Mangul
@@ -347,7 +290,6 @@
   - cancer
   - single cell
   - ovarian cancer
-- *id003
 - title: 'Addressing the Digital Divide in Contemporary Biology: Lessons from Teaching
     UNIX'
   authors:
@@ -517,8 +459,6 @@
   - cancer
   - single cell
   - ovarian cancer
-- *id004
-- *id005
 - title: 'Path to independence: Overview of challenges and opportunities of computational
     data-driven research in biology'
   authors:
@@ -729,7 +669,8 @@
   - cancer
   - single cell
   - ovarian cancer
-- title: Integrating big data analytical techniques in pharmacy education
+- &id003
+  title: Integrating big data analytical techniques in pharmacy education
   authors:
   - Kerui Peng
   - Lana S. Martin
@@ -745,12 +686,49 @@
   - cancer
   - single cell
   - ovarian cancer
-- *id005
-- *id006
-- *id007
-- *id008
+- *id003
 - *id004
-- *id009
+- title: Improving the usability and archival stability of bioinformatics software
+  authors:
+  - Serghei Mangul
+  - Lana S. Martin
+  - Eleazar Eskin
+  - Ran Blekhman
+  publisher: Genome Biology
+  date: '2019-02-27'
+  link: https://doi.org/ggc6j6
+  id: doi:10.1186/s13059-019-1649-8
+  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  tags:
+  - cancer
+  - machine learning
+- title: Improving the usability and comprehensiveness of microbial databases
+  authors:
+  - Caitlin Loeffler
+  - Aaron Karlsberg
+  - Lana S. Martin
+  - Eleazar Eskin
+  - David Koslicki
+  - Serghei Mangul
+  publisher: BMC Biology
+  date: '2020-04-07'
+  link: https://doi.org/ghqfdt
+  id: doi:10.1186/s12915-020-0756-z
+  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  tags:
+  - cancer
+  - machine learning
+- title: Interpreting and integrating big data in the life sciences
+  authors:
+  - Serghei Mangul
+  publisher: Emerging Topics in Life Sciences
+  date: '2019-08-16'
+  link: https://doi.org/d53v
+  id: doi:10.1042/ETLS20180175
+  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  tags:
+  - cancer
+  - machine learning
 - title: How bioinformatics and open data can boost basic science in countries and
     universities with limited resources
   authors:
@@ -770,7 +748,6 @@
   tags:
   - cancer
   - machine learning
-- *id003
 - title: AIRR Community Standardized Representations for Annotated Immune Repertoires
   authors:
   - Jason Anthony Vander Heiden
@@ -888,33 +865,8 @@
   tags:
   - cancer
   - machine learning
-- title: Transcriptome analysis in whole blood reveals increased microbial diversity
-    in schizophrenia
-  authors:
-  - Loes M. Olde Loohuis
-  - Serghei Mangul
-  - Anil P. S. Ori
-  - Guillaume Jospin
-  - David Koslicki
-  - Harry Taegyun Yang
-  - Timothy Wu
-  - Marco P. Boks
-  - Catherine Lomen-Hoerth
-  - Martina Wiedau-Pazos
-  - Rita M. Cantor
-  - Willem M. de Vos
-  - "Ren\xE9 S. Kahn"
-  - Eleazar Eskin
-  - Roel A. Ophoff
-  publisher: Translational Psychiatry
-  date: '2018-05-10'
-  link: https://doi.org/gdkhgz
-  id: doi:10.1038/s41398-018-0107-9
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - cancer
-  - machine learning
-- title: Co-expression networks reveal the tissue-specific regulation of transcription
+- &id005
+  title: Co-expression networks reveal the tissue-specific regulation of transcription
     and splicing
   authors:
   - Ashis Saha
@@ -934,26 +886,7 @@
   tags:
   - cancer
   - machine learning
-- title: Co-expression networks reveal the tissue-specific regulation of transcription
-    and splicing
-  authors:
-  - Ashis Saha
-  - Yungil Kim
-  - Ariel D.H. Gewirtz
-  - Brian Jo
-  - Chuan Gao
-  - Ian C. McDowell
-  - Barbara E. Engelhardt
-  - Alexis Battle
-  - ' '
-  publisher: Genome Research
-  date: '2017-11-01'
-  link: https://doi.org/gb2qx6
-  id: doi:10.1101/gr.216721.116
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - cancer
-  - machine learning
+- *id005
 - title: A comprehensive benchmarking of WGS-based structural variant callers
   authors:
   - Varuni Sarwal
@@ -1015,7 +948,7 @@
   tags:
   - cancer
   - machine learning
-- &id011
+- &id006
   title: Mechanisms of tissue-specific genetic regulation revealed by latent factors
     across eQTLs
   authors:
@@ -1043,8 +976,7 @@
   tags:
   - cancer
   - machine learning
-- &id010
-  title: Refining the conference experience for junior scientists in the wake of climate
+- title: Refining the conference experience for junior scientists in the wake of climate
     change
   authors:
   - Ruth Johnson
@@ -1054,7 +986,7 @@
   date: '2020-06-17'
   link: http://arxiv.org/abs/2002.12268
   id: url:https://arxiv.org/abs/2002.12268
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: ''
   extra-links:
   - type: preprint
   - type: manubot
@@ -1062,8 +994,6 @@
   tags:
   - cancer
   - machine learning
-- *id010
-- *id010
 - title: 'Metalign: Efficient alignment-based metagenomic profiling via containment
     min hash'
   authors:
@@ -1250,8 +1180,8 @@
   tags:
   - cancer
   - machine learning
-- *id011
-- *id011
+- *id006
+- *id006
 - title: Long non-coding RNA gene regulation and trait associations across human tissues
   authors:
   - O. M. de Goede
@@ -1393,7 +1323,6 @@
   tags:
   - cancer
   - machine learning
- 
 - title: A vast resource of allelic expression data spanning human tissues
   authors:
   - Stephane E. Castel
@@ -1414,207 +1343,3 @@
   tags:
   - cancer
   - machine learning
-
-- title: 'RNA-seq data science: From raw data to effective interpretation'
-  authors:
-  - Dhrithi Deshpande
-  - Karishma Chhugani
-  - Yutong Chang
-  - Aaron Karlsberg
-  - Caitlin Loeffler
-  - Jinyang Zhang
-  - Agata Muszynska
-  - Jeremy Rotman
-  - Laura Tao
-  - Brunilda Balliu
-  - Elizabeth Tseng
-  - Fangqing Zhao
-  - Eleazar Eskin
-  - Pejman Mohammadi
-  - Pawel P Labaj
-  - Serghei Mangul
-  - ' '
-  publisher: arXiv:2010.02391v3 (q-bio)
-  date: '2020-10-05'
-  link: https://arxiv.org/abs/2010.02391v3
-  id: doi:10.31219/osf.io/3gdy4
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-  - type: preprint
-  - type: manubot
-    link: https://arxiv.org/abs/2010.02391v3
-  tags:
-  - RNA-seq
-  - archival stability
-  - data-science
- 
-- title: 'Improving the completeness of public metadata accompanying omics studies'
-  authors:
-  - Anushka Rajesh 
-  - Yutong Chang
-  - Malak S Abedalthagafi
-  - Annie Wong-Beringer
-  - Michael I Love 
-  - Serghei Mangul
-  - ' '
-  publisher: Genome Biology
-  date: '2021-04-15'
-  link: https://genomebiology.biomedcentral.com/articles/10.1186/s13059-021-02332-z
-  id: https://doi.org/10.1186/s13059-021-02332-z
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - omics
-  - metadata
-  
-- title: 'Population-scale tissue transcriptomics maps long non-coding RNAs to complex disease'
-  authors:
-  - Olivia M de Goede
-  - Daniel C Nachun
-  - Nicole M Ferraro 
-  - Michael J Gloudeman
-  - Abhiram S Rao
-  - Craig Smail
-  - Tiffany Y Eulalio
-  - François Aguet 
-  - Bernard Ng
-  - Jishu Xu
-  - Alvaro N Barbeira
-  - Stephane E Castel
-  - Sarah Kim-Hellmuth 
-  - YoSon Park 
-  - Alexandra J Scott
-  - Benjamin J Strober
-  - Serghei Mangul (GTex Consortium)
-  - ' '
-  publisher: Cell
-  date: '2021-04-16'
-  link: https://www.sciencedirect.com/science/article/abs/pii/S0092867421003810
-  id: https://doi.org/10.1016/j.cell.2021.03.050
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - long ncRNA
-  - transcriptomics
-  
-- title: 'Ancestry diversity of open T-cell receptor repertoire data, a systematic assessment'
-  authors:
-  - Yu-Ning Huang
-  - Kerui Peng
-  - Serghei Mangul
-  - ' '
-  publisher: OSF Preprints
-  date: '2021-03-01'
-  link: https://osf.io/w25hq
-  id: 10.31219/osf.io/w25hq
-  extra-links:
-  - type: preprint
-  - type: manubot
-    link: 10.31219/osf.io/w25hq
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - ancestry
-  - T-cell repertoire
-  
-- title: 'Dietary supplements and nutraceuticals under investigation for COVID-19 prevention and treatment'
-  authors:
-  - Ronan Lordan
-  - Halie M Rando 
-  - Casey S Greene
-  - Serghei Mangul (COVID-19 Review Consortium)
-  - ' '
-  publisher: ArXiv
-  date: '2021-02-03'
-  link: https://arxiv.org/abs/2102.02250v1
-  id: https://arxiv.org/abs/2102.02250v1
-  extra-links:
-  - type: preprint
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - COVID-19 
-  
-- title: 'The Gene Expression Deconvolution Interactive Tool (GEDIT): Accurate cell type quantification from gene expression data'
-  authors:
-  - Brian B Nadel 
-  - David Lopez 
-  - Dennis J Montoya
-  - Feiyang Ma
-  - Hannah Waddel
-  - Misha M Khan
-  - Serghei Mangul
-  - Matteo Pellegrini
-  publisher: GigaScience
-  date: '2021-02-01'
-  link: https://academic.oup.com/gigascience/article/10/2/giab002/6137724?login=true
-  id: https://doi.org/10.1093/gigascience/giab002
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - cell type quantification
-  - GEDIT
-  - gene expression
- 
-- title: 'Pathogenesis, symptomatology, and transmission of SARS-CoV-2 through analysis of viral genomics and structure'
-  authors:
-  - Halie M Rando
-  - Adam L MacLean
-  - Alexandra J Lee
-  - Sandipan Ray
-  - Vikas Bansal
-  - Ashwin N Skelly
-  - Elizabeth Sell
-  - John J Dziak
-  - Lamonica Shinholster
-  - Lucy D Agostino McGowan
-  - Marouen Ben Guebila
-  - Nils Wellhausen
-  - Sergey Knyazev
-  - Simina M Boca
-  - Stephen Capone
-  - YoSon Park
-  - David Mai
-  - Christian Brueffer
-  - James Brian Byrd
-  - Jinhui Wang
-  - Ronan Lordan
-  - Ryan Velazquez
-  - Gregory L Szeto
-  - John P Barton
-  - Rishi Raj Goel
-  - Serghei Mangul
-  - Tiago Lubiana
-  - Anthony Gitter
-  - Casey S Greene
-  - ' '
-  publisher: ArXiv
-  date: '2021-02-01'
-  link: https://arxiv.org/abs/2102.01521
-  id: https://arxiv.org/abs/2102.01521
-  extra-links:
-  - type: preprint
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - COVID-19 
-  - viral genomics
- 
-- title: 'Systematic evaluation of transcriptomics-based deconvolution methods and references using thousands of clinical samples'
-  authors:
-  - Brian Nadel
-  - Meritxell Oliva
-  - Benjamin L Shou
-  - Keith Mitchell
-  - Feiyang Ma
-  - Dennis J Montoya
-  - Alice Mouton
-  - Sarah Kim-Hellmuth
-  - Barbara Stranger
-  - Matteo Pellegrini
-  - Serghei Mangul
-  - ' '
-  publisher: bioRxiv Cold Spring Harbor Laboratory
-  date: '2021-01-01'
-  link: https://www.biorxiv.org/content/10.1101/2021.03.09.434660v1.abstract
-  id: https://doi.org/10.1101/2021.03.09.434660
-  extra-links:
-  - type: preprint
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  tags:
-  - transcriptomics
-  - cell deconvolution

--- a/_data/research-output.yml
+++ b/_data/research-output.yml
@@ -1,5 +1,4 @@
-- &id001
-  title: 'ROP: dumpster diving in RNA-sequencing to find the source of 1 trillion
+- title: 'ROP: dumpster diving in RNA-sequencing to find the source of 1 trillion
     reads across diverse adult human tissues'
   authors:
   - Serghei Mangul
@@ -35,9 +34,7 @@
   - cancer
   - single cell
   - ovarian cancer
-- *id001
-- &id002
-  title: Profiling immunoglobulin repertoires across multiple human tissues using
+- title: Profiling immunoglobulin repertoires across multiple human tissues using
     RNA sequencing
   authors:
   - Igor Mandric
@@ -62,43 +59,10 @@
   date: '2020-06-19'
   link: https://doi.org/ghqfdr
   id: doi:10.1038/s41467-020-16857-7
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
   tags:
   - cancer
   - machine learning
-- title: 'ROP: dumpster diving in RNA-sequencing to find the source of 1 trillion
-    reads across diverse adult human tissues'
-  authors:
-  - Serghei Mangul
-  - Harry Taegyun Yang
-  - Nicolas Strauli
-  - Franziska Gruhl
-  - Hagit T. Porath
-  - Kevin Hsieh
-  - Linus Chen
-  - Timothy Daley
-  - Stephanie Christenson
-  - Agata Wesolowska-Andersen
-  - Roberto Spreafico
-  - Cydney Rios
-  - Celeste Eng
-  - Andrew D. Smith
-  - Ryan D. Hernandez
-  - Roel A. Ophoff
-  - Jose Rodriguez Santana
-  - Erez Y. Levanon
-  - Prescott G. Woodruff
-  - Esteban Burchard
-  - Max A. Seibold
-  - Sagiv Shifman
-  - Eleazar Eskin
-  - Noah Zaitlen
-  publisher: Genome Biology
-  date: '2018-02-15'
-  link: https://doi.org/ggn2dj
-  id: doi:doi:10.1186/s13059-018-1403-7
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
-- *id002
 - title: Accurate viral population assembly from ultra-deep sequencing data
   authors:
   - S. Mangul
@@ -153,8 +117,7 @@
   - cancer
   - single cell
   - ovarian cancer
-- &id004
-  title: Systematic benchmarking of omics computational tools
+- title: Systematic benchmarking of omics computational tools
   authors:
   - Serghei Mangul
   - Lana S. Martin
@@ -168,10 +131,11 @@
   date: '2019-03-27'
   link: https://doi.org/gfxx3z
   id: doi:10.1038/s41467-019-09406-4
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
   tags:
   - cancer
-  - machine learning
+  - single cell
+  - ovarian cancer
 - title: Challenges and recommendations to improve the installability and archival
     stability of omics computational tools
   authors:
@@ -251,7 +215,7 @@
   date: '2020-01-08'
   link: https://doi.org/ghjzd4
   id: doi:10.1093/nar/gkz822
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/nar/48/D1/10.1093_nar_gkz822/1/gkz822fig2.jpeg?Expires=1627396020&Signature=0zOulYw0i2LLSmY8mQHgoCJAay~ccQuLxUhZqvcjEqog10p2dGj05uxonDH66c7~69KmN0joOPaAfVRMjfUfwV72I5rPB8ctOesZVAIQacRPyjgUBHFjEr~y~nFEOkKqTA1CqETli5qqN-cdTgNCu64pyllxjrbITWheWZ5hRJ88KQIuZMlq7MxrVkgnOL-UZ0ipxseAccWLAMWJPFzAsgrjIa~vWuR42oiA3Dl7jjJ1Oz1UzlJn~6aLEzfBC1OmPduICHxa~7~l2eVCU13D8lfqYIJJVuEIPysIBQ0TLVRM0F9NH7a7qHFJN27a7Jwuv7Nta6bd3IK1KB80~XjjZg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA
   tags:
   - cancer
   - single cell
@@ -360,7 +324,7 @@
   date: '2021-01-26'
   link: https://doi.org/ghxdc9
   id: doi:10.1186/s13059-020-02252-4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02252-4/MediaObjects/13059_2020_2252_Fig1_HTML.png?as=webp
   tags:
   - cancer
   - single cell
@@ -437,7 +401,7 @@
   date: '2020-09-11'
   link: https://doi.org/ghxddg
   id: doi:10.1186/s13059-020-02113-0
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://media.springernature.com/full/springer-static/image/art%3A10.1186%2Fs13059-020-02113-0/MediaObjects/13059_2020_2113_Fig4_HTML.png?as=webp
   tags:
   - cancer
   - single cell
@@ -469,7 +433,7 @@
   date: '2020-11-25'
   link: https://doi.org/ghxddk
   id: doi:10.31219/osf.io/v5kr4
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: ''
   tags:
   - cancer
   - single cell
@@ -664,13 +628,12 @@
   date: '2020-09-11'
   link: https://doi.org/ghxdfd
   id: doi:10.1126/science.aaz5900
-  image: https://www.biorxiv.org/content/biorxiv/early/2020/11/07/2020.11.06.371963/F4.medium.gif
+  image: https://science.sciencemag.org/content/sci/369/6509/eaaz5900/F1.large.jpg?width=800&height=600
   tags:
   - cancer
   - single cell
   - ovarian cancer
-- &id003
-  title: Integrating big data analytical techniques in pharmacy education
+- title: Integrating big data analytical techniques in pharmacy education
   authors:
   - Kerui Peng
   - Lana S. Martin
@@ -686,8 +649,6 @@
   - cancer
   - single cell
   - ovarian cancer
-- *id003
-- *id004
 - title: Improving the usability and archival stability of bioinformatics software
   authors:
   - Serghei Mangul
@@ -865,8 +826,7 @@
   tags:
   - cancer
   - machine learning
-- &id005
-  title: Co-expression networks reveal the tissue-specific regulation of transcription
+- title: Co-expression networks reveal the tissue-specific regulation of transcription
     and splicing
   authors:
   - Ashis Saha
@@ -886,7 +846,6 @@
   tags:
   - cancer
   - machine learning
-- *id005
 - title: A comprehensive benchmarking of WGS-based structural variant callers
   authors:
   - Varuni Sarwal
@@ -910,7 +869,7 @@
   date: '2020-09-17'
   link: https://doi.org/ggsfx4
   id: doi:10.1101/2020.04.16.045120
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/09/17/2020.04.16.045120/F2.large.jpg?width=800&height=600
   extra-links:
   - type: preprint
   - type: manubot
@@ -948,8 +907,7 @@
   tags:
   - cancer
   - machine learning
-- &id006
-  title: Mechanisms of tissue-specific genetic regulation revealed by latent factors
+- title: Mechanisms of tissue-specific genetic regulation revealed by latent factors
     across eQTLs
   authors:
   - Yuan He
@@ -1006,7 +964,7 @@
   date: '2020-01-18'
   link: https://doi.org/ghqfdx
   id: doi:10.1101/2020.01.17.910521
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
+  image: https://www.biorxiv.org/content/biorxiv/early/2020/01/18/2020.01.17.910521/F1.large.jpg?width=800&height=600
   extra-links:
   - type: preprint
   - type: manubot
@@ -1061,50 +1019,6 @@
   - type: preprint
   - type: manubot
     link: https://doi.org/10.1101/833210
-  tags:
-  - cancer
-  - machine learning
-- title: Exploiting the GTEx resources to decipher the mechanisms at GWAS loci
-  authors:
-  - Alvaro N Barbeira
-  - Rodrigo Bonazzola
-  - Eric R Gamazon
-  - Yanyu Liang
-  - YoSon Park
-  - Sarah Kim-Hellmuth
-  - Gao Wang
-  - Zhuoxun Jiang
-  - Dan Zhou
-  - Farhad Hormozdiari
-  - Boxiang Liu
-  - Abhiram Rao
-  - Andrew R Hamel
-  - Milton D Pividori
-  - "Fran\xE7ois Aguet"
-  - Lisa Bastarache
-  - Daniel M Jordan
-  - Marie Verbanck
-  - Ron Do
-  - Matthew Stephens
-  - Kristin Ardlie
-  - Mark McCarthy
-  - Stephen B Montgomery
-  - "Ayellet V Segr\xE8"
-  - Christopher D. Brown
-  - Tuuli Lappalainen
-  - Xiaoquan Wen
-  - Hae Kyung Im
-  - ' '
-  - ' '
-  publisher: Cold Spring Harbor Laboratory
-  date: '2020-05-23'
-  link: https://doi.org/gg7m54
-  id: doi:10.1101/814350
-  image: https://user-images.githubusercontent.com/542643/97004985-cb072a00-150b-11eb-9d4b-765ec1893a11.png
-  extra-links:
-  - type: preprint
-  - type: manubot
-    link: https://doi.org/10.1101/814350
   tags:
   - cancer
   - machine learning
@@ -1180,8 +1094,6 @@
   tags:
   - cancer
   - machine learning
-- *id006
-- *id006
 - title: Long non-coding RNA gene regulation and trait associations across human tissues
   authors:
   - O. M. de Goede


### PR DESCRIPTION
This PR removes duplicate research paper entries on the website and updates all research article images. Currently the same two images are used for all articles.

Closes #85 

TODO:
- [x] Remove all duplicates
- [ ] Update all article images
- [ ] Add new articles